### PR TITLE
Perbaiki typo 'wiraswata' menjadi 'wiraswasta'

### DIFF
--- a/docs/kata/gabungan-kata.md
+++ b/docs/kata/gabungan-kata.md
@@ -85,4 +85,4 @@ Misalnya:
 - sukacita
 - sukarela
 - syahbandar
-- wiraswata
+- wiraswasta


### PR DESCRIPTION
'wiraswata' tidak ditemukan di KBBI (https://kbbi.web.id/wiraswata), sementara 'wiraswasta' ditemukan. (https://kbbi.web.id/wiraswasta)