### PR TITLE
Luruskan titik dua pada contoh

### DIFF
--- a/docs/tanda-baca/tanda-titik-dua.md
+++ b/docs/tanda-baca/tanda-titik-dua.md
@@ -25,21 +25,21 @@ d. pelaporan.
 
 Misalnya:
 
-- Ketua : Ahmad Wijaya  
-Sekretaris : Siti Aryani  
-Bendahara : Aulia Arimbi
-- Narasumber : Prof. Dr. Rahmat Effendi  
-Pemandu : Abdul Gani, M.Hum.  
-Pencatat : Sri Astuti Amelia, S.Pd.  
+- <span style="display: inline-block; width: 6em;">Ketua</span>: Ahmad Wijaya  
+<span style="display: inline-block; width: 6em;">Sekretaris</span>: Siti Aryani  
+<span style="display: inline-block; width: 6em;">Bendahara</span>: Aulia Arimbi
+- <span style="display: inline-block; width: 6em;">Narasumber</span>: Prof. Dr. Rahmat Effendi  
+<span style="display: inline-block; width: 6em;">Pemandu</span>: Abdul Gani, M.Hum.  
+<span style="display: inline-block; width: 6em;">Pencatat</span>: Sri Astuti Amelia, S.Pd.  
 
 !!! important ""
 	**III.D.4** Tanda titik dua dipakai dalam naskah drama sesudah kata yang menunjukkan pelaku dalam percakapan.
 
 Misalnya:
 
-- Ibu : "Bawa koper ini, Nak!"  
-Amir : "Baik, Bu."  
-Ibu : "Jangan lupa, letakkan baik-baik!"  
+- <span style="display: inline-block; width: 3em;">Ibu</span>: "Bawa koper ini, Nak!"  
+<span style="display: inline-block; width: 3em;">Amir</span>: "Baik, Bu."  
+<span style="display: inline-block; width: 3em;">Ibu</span>: "Jangan lupa, letakkan baik-baik!"  
 
 !!! important ""
 	**III.D.5** Tanda titik dua dipakai di antara (a) jilid atau nomor dan halaman, (b) surah dan ayat dalam kitab suci, (c) judul dan anak judul suatu karangan, serta (d) nama kota dan penerbit dalam daftar pustaka.


### PR DESCRIPTION
Terdapat spasi sebelum tanda titik dua pada contoh III.D.3 dan III.D.4 (Tanda Titik Dua) yang dapat menyebabkan kesalahpahaman dalam aturan perlu tidaknya spasi sebelum tanda titik dua.

![Screen Shot 2022-04-23 at 18 25 00](https://user-images.githubusercontent.com/100836456/164965178-08de248a-8081-489a-8523-dc143dca5e87.png)

Hal tersebut saya duga karena belum diterapkannya format gaya sesuai dokumen asli, yaitu lurusnya titik dua secara vertikal pada kasus pemerian multibaris dan percakapan naskah drama.

![Screen Shot 2022-04-23 at 18 25 50](https://user-images.githubusercontent.com/100836456/164965199-e6966444-adfd-4627-883e-f2fa4b6c9aa6.png)

_Pull request_ ini menerapkan format gaya sesuai dokumen asli.

![Screen Shot 2022-04-23 at 18 26 48](https://user-images.githubusercontent.com/100836456/164965209-0c9192c4-cde1-405c-b649-670910743c40.png)

Namun, karena saya tidak menemukan cara untuk menerapkannya menggunakan Markdown, sebagai alternatif, saya menggunakan HTML dan CSS _inline_.

Sambil lalu, saya yang pernah menanyakan soal ini [di Bahas Bahasa](https://t.me/bahasbahasa/78277), Uda. 🙏 Kebetulan baru mencoba mulai main platform ini.

n.b. MkDocs versi 1.2.3 [ada eror](https://github.com/mkdocs/mkdocs/issues/2799#issuecomment-1079764329).